### PR TITLE
Overview pricing fix.

### DIFF
--- a/client/components/Overview/Overview components/ProductInfo components/Info.jsx
+++ b/client/components/Overview/Overview components/ProductInfo components/Info.jsx
@@ -11,8 +11,11 @@ const styling = {
     fontSize: 25,
     marginLeft: 15,
   },
-  original: {
+  originalSale: {
     textDecoration: 'line-through',
+    fontSize: 25,
+  },
+  originalNoSale: {
     fontSize: 25,
   },
   flex: {
@@ -34,11 +37,11 @@ const Info = ({currentProd, style}) => (
     {style.sale_price
       ? (
         <div style={styling.flex}>
-          <div style={styling.original}>${style.original_price}</div>
+          <div style={styling.originalSale}>${style.original_price}</div>
           <div style={styling.sale}>${style.sale_price}</div>
         </div>
       )
-      : <div style={styling.original}>${style.original_price}</div>}
+      : <div style={styling.originalNoSale}>${style.original_price}</div>}
   </StyledPInfoContainer>
 );
 


### PR DESCRIPTION
https://trello.com/c/yrSpohWI/128-update-product-price-to-show-sale-price-of-current-style-with-original-price-struckthrough

Fix to styling on pricing. Should correctly render the price now.