### PR TITLE
Fix quantity selector bug. Add additional keys to other dropdown options.

### DIFF
--- a/client/components/Overview/Overview components/ProductInfo components/Cart.jsx
+++ b/client/components/Overview/Overview components/ProductInfo components/Cart.jsx
@@ -30,9 +30,9 @@ class Cart extends React.Component {
     super(props);
     this.state = {
       items: [],
-      inventory: [],
       sizes: [],
       quantities: [],
+      currentStyle: '',
     };
     this.parseInventory = this.parseInventory.bind(this);
     this.updateSizeSelection = this.updateSizeSelection.bind(this);
@@ -67,7 +67,7 @@ class Cart extends React.Component {
       sizes.push(product.size);
 
       // Fill quantities based on selected size. Max 15
-      if (currentSize === product.size) {
+      if (currentSize === product.size && this.state.currentStyle.length > 0) {
         let totalQuantity = product.quantity;
         if (totalQuantity > 15) {
           totalQuantity = 15;
@@ -80,7 +80,6 @@ class Cart extends React.Component {
     });
 
     this.setState({
-      inventory: skus,
       sizes: sizes,
       quantities: quantities,
     });
@@ -88,7 +87,9 @@ class Cart extends React.Component {
 
   // Pass selected style into parse to render correct quantities
   updateSizeSelection(size) {
-    this.parseInventory(this.props.currentStyle.skus, size.target.value);
+    this.setState({ currentStyle: size.target.value }, () => {
+      this.parseInventory(this.props.currentStyle.skus, size.target.value);
+    });
   }
 
   render() {

--- a/client/components/Overview/Overview components/ProductInfo components/DropDownSize.jsx
+++ b/client/components/Overview/Overview components/ProductInfo components/DropDownSize.jsx
@@ -12,8 +12,8 @@ const DropDownSize = (props) => {
   return (
     <select id={`${props.default}}`} onChange={props.select}>
       <option selected disabled>SELECT SIZE</option>
-      {props.sizes.map((size) => {
-        return <option value={size}>{size}</option>
+      {props.sizes.map((size, index) => {
+        return <option value={size} key={index}>{size}</option>
       })}
     </select>
   );


### PR DESCRIPTION
https://trello.com/c/qUyp8h26/150-fix-jacket-quantity-selector-bug-occasionally-not-disabled-due-to-having-inventory-before-size-is-selected

Found the bug and put in a fix for it.
Also saw that there were still keys missing for the other dropdown component I made for size. Added those keys as well.