### PR TITLE
Formatting changes.

### DIFF
--- a/client/components/Overview/Overview components/ImageGallery.jsx
+++ b/client/components/Overview/Overview components/ImageGallery.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const styling = {
   default: {
-    width: 800,
-    height: 800,
+    width: 600,
+    height: 600,
     objectFill: 'contain',
   },
 };

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -150,7 +150,8 @@ ul {
   font-size: 50px;
   display: grid;
   grid-template-columns: 60% 40%;
-  grid-template-rows: 7.5% 5% 65% 22.5%;
+  /* grid-template-rows: 7.5% 5% 65% 22.5%; */
+  grid-template-rows: auto;
   justify-content: left;
 }
 


### PR DESCRIPTION
https://trello.com/c/m382x6fS/144-fix-rendering-locations-of-components-inside-overview-widget

Hey, all. I put in some small formatting changes. The rows are on auto and I scaled the hardcoded picture size down for now. This should have the Overview section rendering a lot cleaner for later today's presentation and I can work on the image gallery as much as possible until then.